### PR TITLE
Fixes typo in FAQ

### DIFF
--- a/content/pages/4.faq.md
+++ b/content/pages/4.faq.md
@@ -67,7 +67,7 @@ Slug: faq
 
     BSD 3-clause license. https://github.com/dbcli/mycli/blob/master/LICENSE.txt
    
-1. **How can I get support for pgcli?**
+1. **How can I get support for mycli?**
 
     There is a [mailing list](https://groups.google.com/forum/#!forum/mycli-users) 
     and [Gitter](https://gitter.im/dbcli/mycli) chat. We also track our bugs


### PR DESCRIPTION
Question 4 in the FAQ had 'pgcli' instead of 'mycli'. This fixes that.