### PR TITLE
Add Python 3.5 to install page.

### DIFF
--- a/content/pages/1.install.md
+++ b/content/pages/1.install.md
@@ -3,7 +3,7 @@ Slug: install
 
 # Compatibility:
 
-Tested on OS X and Linux. Runs on Python 2.6, 2.7, 3.3 and 3.4.
+Tested on OS X and Linux. Runs on Python 2.6, 2.7, 3.3, 3.4, and 3.5.
 
 Works well with unicode input/output.
 


### PR DESCRIPTION
Mycli is now tested with Python 3.5.