### PR TITLE
Update macOS language, Python version, and usage

### DIFF
--- a/content/pages/0.index.md
+++ b/content/pages/0.index.md
@@ -33,35 +33,38 @@ detailed instructions.
      Usage: mycli [OPTIONS] [DATABASE]
 
      Options:
-	-h, --host TEXT               Host address of the database.
-	-P, --port TEXT               Port number to use for connection. Honors
-					              $MYSQL_TCP_PORT
-	-u, --user TEXT               User name to connect to the database.
-	-S, --socket TEXT             The socket file to use for connection.
-	-p, --password                Force password prompt.
-	--pass TEXT                   Password to connect to the database
-	--ssl-ca PATH                 CA file in PEM format
-	--ssl-capath TEXT             CA directory
-	--ssl-cert PATH               X509 cert in PEM format
-	--ssl-key PATH                X509 key in PEM format
-	--ssl-cipher TEXT             SSL cipher to use
-	--ssl-verify-server-cert      Verify server's "Common Name" in its cert
-				                  against hostname used when connecting. This
-				                  option is disabled by default
-	-v, --version                 Version of mycli.
-	-D, --database TEXT           Database to use.
-	-R, --prompt TEXT             Prompt format (Default: "\t \u@\h:\d> ")
-	-l, --logfile FILENAME        Log every query and its results to a file.
-	--defaults-group-suffix TEXT  Read config group with the specified suffix.
-	--defaults-file PATH          Only read default options from the given file
-	--auto-vertical-output        Automatically switch to vertical output mode
-				                  if the result is wider than the terminal
-				                  width.
-	-t, --table                   Display batch output in table format.
-	--warn / --no-warn            Warn before running a destructive query.
-	--local-infile BOOLEAN        Enable/disable LOAD DATA LOCAL INFILE.
-	--login-path TEXT             Read this path from the login file.
-	--help                        Show this message and exit.
+       -h, --host TEXT               Host address of the database.
+       -P, --port INTEGER            Port number to use for connection. Honors
+                                     $MYSQL_TCP_PORT
+       -u, --user TEXT               User name to connect to the database.
+       -S, --socket TEXT             The socket file to use for connection.
+       -p, --password TEXT           Password to connect to the database
+       --pass TEXT                   Password to connect to the database
+       --ssl-ca PATH                 CA file in PEM format
+       --ssl-capath TEXT             CA directory
+       --ssl-cert PATH               X509 cert in PEM format
+       --ssl-key PATH                X509 key in PEM format
+       --ssl-cipher TEXT             SSL cipher to use
+       --ssl-verify-server-cert      Verify server's "Common Name" in its cert
+                                     against hostname used when connecting. This
+                                     option is disabled by default
+       -v, --version                 Version of mycli.
+       -D, --database TEXT           Database to use.
+       -R, --prompt TEXT             Prompt format (Default: "\t \u@\h:\d> ")
+       -l, --logfile FILENAME        Log every query and its results to a file.
+       --defaults-group-suffix TEXT  Read config group with the specified suffix.
+       --defaults-file PATH          Only read default options from the given file
+       --myclirc PATH                Location of myclirc file.
+       --auto-vertical-output        Automatically switch to vertical output mode
+                                     if the result is wider than the terminal
+                                     width.
+       -t, --table                   Display batch output in table format.
+       --csv                         Display batch output in CSV format.
+       --warn / --no-warn            Warn before running a destructive query.
+       --local-infile BOOLEAN        Enable/disable LOAD DATA LOCAL INFILE.
+       --login-path TEXT             Read this path from the login file.
+       -e, --execute TEXT            Execute query to the database.
+       --help                        Show this message and exit.
 
 # Examples
 

--- a/content/pages/0.index.md
+++ b/content/pages/0.index.md
@@ -19,7 +19,7 @@ If you already know how to install python packages, then you can simply do:
     :::bash
     $ pip install mycli
 
-If you're on OS X you can install it via homebrew.
+If you're on MacOS you can install it via homebrew.
 
     :::bash
     $ brew update && brew install mycli

--- a/content/pages/0.index.md
+++ b/content/pages/0.index.md
@@ -19,7 +19,7 @@ If you already know how to install python packages, then you can simply do:
     :::bash
     $ pip install mycli
 
-If you're on MacOS you can install it via homebrew.
+If you're on macOS you can install it via homebrew.
 
     :::bash
     $ brew update && brew install mycli

--- a/content/pages/1.install.md
+++ b/content/pages/1.install.md
@@ -3,7 +3,7 @@ Slug: install
 
 # Compatibility:
 
-Tested on MacOS and Linux. Runs on Python 2.7, 3.3, 3.4, 3.5, and 3.6.
+Tested on macOS and Linux. Runs on Python 2.7, 3.3, 3.4, 3.5, and 3.6.
 
 Works well with unicode input/output.
 
@@ -21,7 +21,7 @@ You might need ``sudo``.
     $ easy_install mycli
 
 
-# MacOS:
+# macOS:
 
 The easiest way install ``mycli`` on a Mac is to use [homebrew].
 

--- a/content/pages/1.install.md
+++ b/content/pages/1.install.md
@@ -3,7 +3,7 @@ Slug: install
 
 # Compatibility:
 
-Tested on OS X and Linux. Runs on Python 2.6, 2.7, 3.3, 3.4, and 3.5.
+Tested on MacOS and Linux. Runs on Python 2.6, 2.7, 3.3, 3.4, and 3.5.
 
 Works well with unicode input/output.
 
@@ -11,19 +11,19 @@ Works well with unicode input/output.
 
 If you already know how to install python packages, then you can do:
 
-You might need ``sudo``. 
+You might need ``sudo``.
 
     :::bash
     $ pip install mycli
 
-    or 
+    or
 
     $ easy_install mycli
 
 
-# Mac OS X:
+# MacOS:
 
-The easiest way install ``mycli`` in an OS X machine is to use [homebrew].
+The easiest way install ``mycli`` on a Mac is to use [homebrew].
 
     :::bash
     $ brew update && brew install mycli

--- a/content/pages/1.install.md
+++ b/content/pages/1.install.md
@@ -3,7 +3,7 @@ Slug: install
 
 # Compatibility:
 
-Tested on MacOS and Linux. Runs on Python 2.6, 2.7, 3.3, 3.4, and 3.5.
+Tested on MacOS and Linux. Runs on Python 2.7, 3.3, 3.4, 3.5, and 3.6.
 
 Works well with unicode input/output.
 

--- a/content/pages/develop.md
+++ b/content/pages/develop.md
@@ -20,9 +20,9 @@ and send pull requests to a repository.
 
 The basic steps are:
 
-1. Fork the mycli project via the github UI. 
+1. Fork the mycli project via the github UI.
 
-1. Clone your fork to your local machine. 
+1. Clone your fork to your local machine.
 
 ```
     git clone git@github.com:<your-username>/mycli.git
@@ -36,17 +36,17 @@ The basic steps are:
 ```
 
 1. Make the necessary changes in your local machine. Commit and push to your
-   fork. 
+   fork.
 
 ```
-       $ git commit 
+       $ git commit
 
-       $ git push origin 
+       $ git push origin
 ```
 
-1. Create a pull request from your fork to the mainline repo using Github UI. 
+1. Create a pull request from your fork to the mainline repo using Github UI.
 
-1. Sync with the main mycli repo. 
+1. Sync with the main mycli repo.
 
 
 ```
@@ -74,7 +74,7 @@ working folder into the virtualenv. By installing it using `pip install -e`
 we've linked the mycli installation with the working copy. So any changes made
 to the code is immediately available in the installed version of mycli. This
 makes it easy to change something in the code, launch mycli and check the
-effects of your change. 
+effects of your change.
 
 ## Tests
 
@@ -82,11 +82,11 @@ The tests are located in the `tests` directory in the mycli project root.
 
 Tests are written using `py.test` testing framework. Install `py.test` by
 using `pip install pytest` in the virtualenv. Then execute the tests by
-calling `py.test` from the root of the project folder. 
+calling `py.test` from the root of the project folder.
 
-A test runner called `tox` is used to run the tests in Python 2.6, Python 2.7
-and Python 3.3. You can do `pip install tox` and call `tox` from the
-project root to run the tests in all 3 python versions.
+A test runner called `tox` is used to run the tests in Python 2.7 and 3.3+.
+You can do `pip install tox` and call `tox` from the
+project root to run the tests in all supported python versions.
 
 If you'd like to run just one of the test files (say test_sqlcompletion.py)
 then `cd` into the tests folder and execute `py.test test_sqlcompletion.py`
@@ -95,6 +95,6 @@ the tests in that file in all three Python versions.
 
 The tests are also run via [Travis CI](https://travis-ci.org/dbcli/mycli) when
 a new Pull Request is opened. If you have a change and it happens to be failing
-on one of the Python version (typically on Python 3), don't worry about it.
-Just open a pull request and I can help you get it fixed before merging.
+on one of the Python versions, don't worry about it. Just open a pull request
+and I can help you get it fixed before merging.
 


### PR DESCRIPTION
- Update OS X language to the newer macOS.
- Update Python version language to drop 2.6 and include up to 3.6.
- Update usage section.