### PR TITLE
Add pager instructions.

### DIFF
--- a/content/pages/3.docs.md
+++ b/content/pages/3.docs.md
@@ -9,15 +9,15 @@ Auto-completion kicks in as soon as you start typing. The suggestions are contex
 
 ## [Config]({filename}/pages/config.md)<a name="config"></a>
 
-The config file for mycli is located in the home folder (~/.myclirc). 
+The config file for mycli is located in the home folder (~/.myclirc).
 
 [Read More...]({filename}/pages/config.md)
 
 ## [Colors]({filename}/pages/syntax.md)<a name="colors"></a>
 
-Syntax highlighting has plenty of themes that can be changed via the [config]({filename}/pages/config.md) file. 
+Syntax highlighting has plenty of themes that can be changed via the [config]({filename}/pages/config.md) file.
 
-Showcase of various color themes: 
+Showcase of various color themes:
 
 [Gallery]({filename}/pages/syntax.md)
 
@@ -29,13 +29,13 @@ There are two types of keybindings available. Emacs mode and Vi mode. The keybin
 
 ## [Favorite Queries]({filename}/pages/favorites.md)<a name="favorites"></a>
 
-Frequently used queries can be saved as favorite queries with a name. 
+Frequently used queries can be saved as favorite queries with a name.
 
 [Read More...]({filename}/pages/favorites.md)
 
 ## [Logging]({filename}/pages/logging.md)<a name="logging"></a>
 
-Default log file is located at `~/.mycli.log`. There is additional user friendly audit logging. 
+Default log file is located at `~/.mycli.log`. There is additional user friendly audit logging.
 
 [Read More..]({filename}/pages/logging.md)
 
@@ -53,10 +53,15 @@ Use the `\e` command in the prompt, to launch the default editor.
 
 ## [History & Search]({filename}/pages/history.md)<a name="history"></a>
 
-MyCli keeps track of the queries entered in the repl. Up/Down arrow can be used to navigate the history. 
+MyCli keeps track of the queries entered in the repl. Up/Down arrow can be used to navigate the history.
 
 Pressing `<C-r>` will enable incremental history search. So press `<C-r>` and then
 start typing your search term to see the queries narrowed down. You can cycle
 through the matches by pressing `<C-r>` again.
 
 [Read more...]({filename}/pages/history.md)
+
+## [Pager Output]({filename}/pages/pager.md)<a name="pager"></a>
+
+`Mycli` uses pager programs to make it easier to view large result sets. This
+can be configured or disabled.

--- a/content/pages/pager.md
+++ b/content/pages/pager.md
@@ -1,0 +1,49 @@
+Title: Pager
+Slug: pager
+status: hidden
+
+Mycli outputs query results in a pager (e.g. `less`, `more`). This
+allows you to easily view large result sets one page at a time.
+
+## Configuring the Pager
+
+When starting up, mycli checks the `pager` config option in MySQL's option
+files. If it's set, then mycli uses its value as the pager. If it's blank,
+then mycli will use the `PAGER` environment variable's value.
+
+Once mycli is started, you can use the `pager` command to change which pager
+mycli uses. Or, `nopager` will disable the pager.
+
+```
+> pager less
+PAGER set to less.
+> nopager
+Pager disabled.
+```
+
+## Disable Paging
+
+You can disable the pager by adding `skip-pager = on` to the `[client]` section
+of your MySQL option file. See [Configuration](/config) for more information.
+
+## Pager Behavior
+
+On macOS and Linux, the pager will default to `less` for most users. `less`
+sometimes has less-than-desirable behavior like clearing the screen, cutting
+lines off, etc. You can configure `less` through environment variables in your
+shell configuration files. Here are some common `less` options and
+configuration examples:
+
+- `-X` leaves file contents on the screen when less exits.
+- `-F` makes `less` quit if the entire output can be displayed on one
+  screen.
+- `-R` displays ANSI color escape sequences in "raw" form.
+- `-S` disables line wrapping. Side-scroll to see long lines.
+
+```
+# This is a popular option among mycli users.
+export LESS="-XFR"
+
+# Some mycli users like to disable line wrapping.
+export LESS="-SRXF"
+```


### PR DESCRIPTION
This adds pager instructions to the documentation.

**NOTE:** this should not be merged/deployed until #12 is.