### PR TITLE
Release 1.16.0

### DIFF
--- a/content/pages/config.md
+++ b/content/pages/config.md
@@ -126,6 +126,10 @@ Token.Toolbar.Arg.Text = 'nobold'
 
 # Favorite queries.
 [favorite_queries]
+
+# DSN to call by -d option
+[alias_dsn]
+# example_dsn = mysql://[user[:password]@][netloc][:port][/dbname]
 ```
 
 ## Sample MySQL Option File

--- a/content/pages/config.md
+++ b/content/pages/config.md
@@ -126,9 +126,9 @@ Token.Toolbar.Arg.Text = 'nobold'
 # Favorite queries.
 [favorite_queries]
 
-# DSN to call by -d option
+# Use the -d option to reference a DSN.
 [alias_dsn]
-# example_dsn = mysql://[user[:password]@][netloc][:port][/dbname]
+# example_dsn = mysql://[user[:password]@][host][:port][/dbname]
 ```
 
 ## Sample MySQL Option File

--- a/content/pages/config.md
+++ b/content/pages/config.md
@@ -5,7 +5,7 @@ status: hidden
 ## Introduction
 
 Most of mycli's user settings are configured via the file located at
-`~/.myclirc`, which is a hidden file in your home folder in Linux and OS X.
+`~/.myclirc`, which is a hidden file in your home folder in Linux and macOS.
 On Windows it is located at `C:\Users\<username>\.myclirc`.
 
 The config file is created when mycli is launched for the very first time.
@@ -19,10 +19,9 @@ page for more information.
 **NOTE:** Mycli does not read the `[mysql]` section of MySQL's option files. It
 only reads the `[client]` section.
 
-MySQL recommends that users store their passwords in an encrypted login path
-file. Mycli will read this file. For more information about how to store your
-authentication credentials in this file, see the [MySQL Configuration Utility
-documentation](https://dev.mysql.com/doc/refman/5.7/en/mysql-config-editor.html).
+Mycli supports two methods of storing server credentials. See the
+[server configuration documentation]({filename}/pages/loginpath.md)
+for more information.
 
 
 ## Sample Mycli Config File

--- a/content/pages/loginpath.md
+++ b/content/pages/loginpath.md
@@ -1,14 +1,30 @@
-Title: Storing server configuration
+Title: Storing Server Configuration
 Slug: loginpath
 status: hidden
 
 
-When working with multiple servers, it is advisable to use the
-[`mysql_config_editor`](https://dev.mysql.com/doc/refman/5.7/en/mysql-config-editor.html)
-tool that ships with MySQL to store the authentication credentials in an encrypted file called
-`.mylogin.cnf`. Then, `mycli` can read and use those credentials.
+When working with multiple servers, it is convenient to store your host and login
+configuration so you don't have to type it in every time you connect to a
+database server. Mycli supports two ways of storing server and authentication credentials.
 
-First, run the `mysql_config_editor` tool and enter the credentials:
+1. The [`mysql_config_editor`](https://dev.mysql.com/doc/refman/5.7/en/mysql-config-editor.html)
+  tool that ships with MySQL. It stores the authentication credentials in an
+  encrypted login path file named `.mylogin.cnf`. Mycli can read and use those
+  credentials. This method is recommended by MySQL.
+2. Mycli's [config file]({filename}/pages/config.md) via DSN aliases.
+
+## MySQL's `mysql_config_editor` <a name="mysql_config_editor"></a>
+
+MySQL's login path file is a convenient way to store your authentication
+credentials in an encrypted file. The login path file encryption prevents
+plaintext credentials from being displayed on the screen or in an editor,
+however if an attacker has access to the file, they can easily decrypt
+it.
+
+To set up a login path, first, run the
+[`mysql_config_editor`](https://dev.mysql.com/doc/refman/5.7/en/mysql-config-editor.html)
+tool and enter the credentials. Storing a password is optional. If there is no
+password stored for a login path and mycli cannot connect, it will ask for one.
 
 ```
 $ mysql_config_editor set --login-path=my_server_alias --host=my.host.address --user=myusername --password
@@ -19,4 +35,41 @@ Then, provide the `--login-path` option when running `mycli`:
 
 ```
 $ mycli --login-path my_server_alias my_database_name
+```
+
+## Mycli's Config File <a name="dsn"></a>
+
+You can store server connections as easy-to-remember aliases in mycli's
+[configuration file]({filename}/pages/config.md). These connection settings,
+also known as DSNs (Data Source Names), can contain the following information:
+
+- Alias
+- Host Name
+- Port
+- Database Name
+- Username
+- Password
+
+If a password is not supplied and mycli cannot connect to the server, it will
+prompt you to enter one. This is helpful so you do not have to store your
+password in a plaintext configuration file.
+
+Here is an example DSN configuration:
+
+```
+[alias_dsn]
+test = mysql://my_user:password@localhost:3306/test_db
+```
+
+When starting up mycli, you can use a DSN by providing the `-d` flag:
+
+```
+$ mycli -d test
+```
+
+You should set the permissions of your configuration file so that only your
+user can read and write to it. In macOS and Linux, you can do this via `chmod`:
+
+```
+$ chmod 700 ~/.myclirc
 ```

--- a/content/release_1.16.0.md
+++ b/content/release_1.16.0.md
@@ -1,0 +1,23 @@
+Title: Release v1.15.0
+Date: 2018-01-01
+Category: Blog
+Author: Thomas Roten
+Tags: python, release, changelog, mysql
+Slug: v1.16.0
+
+`mycli` is a command line interface for MySQL that includes
+auto-completion and syntax highlighting. [Read the install instructions]({filename}/pages/1.install.md) to find out how to get the latest version.
+
+Mycli 1.16.0 was released on January 1, 2018 and includes these changes:
+
+## Features
+
+* Add [DSN aliases]({filename}/pages/loginpath.md#dsn) to the config file (Thanks: [Frederic Aoustin]).
+
+## Bug Fixes
+
+* Do not try to connect to a unix socket on Windows (Thanks: [Thomas Roten]).
+
+
+[Frederic Aoustin]: https://github.com/fraoustin
+[Thomas Roten]: https://github.com/tsroten

--- a/content/release_1.16.0.md
+++ b/content/release_1.16.0.md
@@ -1,4 +1,4 @@
-Title: Release v1.15.0
+Title: Release v1.16.0
 Date: 2018-01-01
 Category: Blog
 Author: Thomas Roten


### PR DESCRIPTION
Adds a 1.16.0 release blog post as well as DSN documentation.

Also, updates the login path documentation to be clearer about the security intent and scope of the encryption.