### PR TITLE
Updates for v1.17.0.

### DIFF
--- a/content/pages/0.index.md
+++ b/content/pages/0.index.md
@@ -55,8 +55,13 @@ detailed instructions.
       --ssl-verify-server-cert      Verify server's "Common Name" in its cert
                                     against hostname used when connecting. This
                                     option is disabled by default.
-      -v, --version                 Output mycli's version.
+      -V, --version                 Output mycli's version.
+      -v, --verbose                 Verbose output.
       -D, --database TEXT           Database to use.
+      -d, --dsn TEXT                Use DSN configured into the [alias_dsn]
+                                    section of myclirc file.
+      --list-dsn                    list of DSN configured into the [alias_dsn]
+                                    section of myclirc file.
       -R, --prompt TEXT             Prompt format (Default: "\t \u@\h:\d> ").
       -l, --logfile FILENAME        Log every query and its results to a file.
       --defaults-group-suffix TEXT  Read MySQL config groups with the specified

--- a/content/pages/config.md
+++ b/content/pages/config.md
@@ -95,6 +95,12 @@ login_path_as_host = False
 # and using normal tabular format otherwise. (This applies to statements terminated by ; or \G.)
 auto_vertical_output = False
 
+# keyword casing preference. Possible values "lower", "upper", "auto"
+keyword_casing = auto
+
+# Enable the pager on startup.
+enable_pager = True
+
 # Custom colors for the completion menu, toolbar, etc.
 [colors]
 # Completion menus.
@@ -167,7 +173,4 @@ loose-local-infile = on
 
 # Configure the pager
 pager = 'vim -'
-
-# Disable the pager
-# skip-pager = on
 ```

--- a/content/pages/pager.md
+++ b/content/pages/pager.md
@@ -23,8 +23,8 @@ Pager disabled.
 
 ## Disable Paging
 
-You can disable the pager by adding `skip-pager = on` to the `[client]` section
-of your MySQL option file. See [Configuration](/config) for more information.
+You can disable the pager by adding `enable_pager = False` to your mycli config
+file. See [Configuration](/config) for more information.
 
 ## Pager Behavior
 


### PR DESCRIPTION
This has a few updates for version 1.17.0:
1. Updates the usage description.
2. Promotes the use of `enable_pager` in the mycli configuration file instead of `skip-pager` in the MySQL option file.
3. Adds a missing config option `keyword_casing`.