### PR TITLE
updated installation instructions

### DIFF
--- a/content/pages/1.install.md
+++ b/content/pages/1.install.md
@@ -3,28 +3,30 @@ Slug: install
 
 # Compatibility:
 
-Mycli is tested on macOS and Linux. It runs on Python 2.7 and 3.4+.
+Mycli is tested on macOS and Linux. It runs on Python 3.6+.
 
 Works well with unicode input/output.
 
-**NOTE:** Python 2.6 support was dropped in mycli 1.9.0. If you're running
+**NOTE:** **Python 2.6** support was dropped in mycli 1.9.0. If you're running
 Python 2.6, you'll want to install mycli 1.8.1.
+**NOTE:** Support for **Python versions 2.7 and 3.0 - 3.5** was dropped in mycli 1.21.0. If you're running
+these versions of Python, you'll want to install mycli 1.20.0
 
 
 
 # Python Package:
 
-If you already know how to install python packages, then you can do:
+The recommended way to install mycli is using the pip package manager ([installation instructions for pip](https://pip.pypa.io/en/stable/installing/)).
 
 You might need ``sudo``.
 
     :::bash
-    $ pip install mycli
+    $ pip3 install mycli
 
-or
+To install older versions, you may use e.g.
 
     :::bash
-    $ easy_install mycli
+    $ pip install mycli==1.20.0
 
 
 # Windows:
@@ -41,31 +43,7 @@ The easiest way install mycli on a Mac is to use [Homebrew].
 
 # Linux:
 
-### Debian/Ubuntu Package:
-
-[https://packages.debian.org/search?keywords=mycli]
-
-    :::bash
-    $ sudo apt-get update
-    $ sudo apt-get install mycli
-
-### Fedora
-
-    :::bash
-    $ sudo dnf install mycli
-
-### RHEL, Centos:
-
-We don't have packages for RHEL or Centos, yet. Instead, use `pip` to install
-mycli. You can install `pip` on your system using:
-
-    :::bash
-    $ sudo yum install python-pip python-devel
-
-Once that is installed, you can install mycli:
-
-    :::bash
-    $ sudo pip install mycli
+While some distributions ship pre-packaged versions of mycli, these are not maintained by the mycli developers ald can be out-of-date. Please consult your distribution documentation for installation instructions or use pip.
 
 
 [homebrew]: http://brew.sh/

--- a/content/pages/1.install.md
+++ b/content/pages/1.install.md
@@ -43,7 +43,7 @@ The easiest way install mycli on a Mac is to use [Homebrew].
 
 # Linux:
 
-While some distributions ship pre-packaged versions of mycli, these are not maintained by the mycli developers ald can be out-of-date. Please consult your distribution documentation for installation instructions or use pip.
+While some distributions ship pre-packaged versions of mycli, these are not maintained by the mycli developers and can be out-of-date. Please consult your distribution documentation for installation instructions or use pip.
 
 
 [homebrew]: http://brew.sh/


### PR DESCRIPTION
Updated install instructions to reflect the current situation:

- python < 3.6 is deprecated, need to use pip3
- easy_install is deprecated
- linux distribution packages are severely out-of-date, replaced distribution-specific instructions with the recommendation to use pip

I don't know the situation on MacOS, is the homebrew recommendation still valid?