### PR TITLE
Prefer forward-slash /commands in multiple docs

### DIFF
--- a/content/pages/6.about.md
+++ b/content/pages/6.about.md
@@ -22,7 +22,7 @@ Mycli supports
      - `SELECT * FROM users WHERE <tab>` will only show column names.
  * Support for multiline queries.
  * Favorite queries with optional positional parameters. Save a query using
-   `\fs <alias> <query>` and execute it with `\f <alias>`.
+   `/fs <alias> <query>` and execute it with `/f <alias>`.
  * Timing of sql statements and table rendering.
  * Logging every query and its results to a file (disabled by default).
  * Pretty printing of tabular data (with colors!).

--- a/content/pages/commands.md
+++ b/content/pages/commands.md
@@ -6,46 +6,50 @@ status: hidden
 
 Mycli sends most input you enter to the MySQL server as a SQL statement. There
 is also a set of commands that mycli itself will accept. To see these, type
-`help` or `\?` at the prompt:
+`/help` or `/?` at the prompt:
 
 ```text
-mycli> help
-+----------------+----------------------------+------------------------------------------------------------+
-| Command        | Shortcut                   | Description                                                |
-+----------------+----------------------------+------------------------------------------------------------+
-| \G             | \G                         | Display current query results vertically.                  |
-| \clip          | \clip                      | Copy query to the system clipboard.                        |
-| \dt            | \dt[+] [table]             | List or describe tables.                                   |
-| \e             | \e                         | Edit command with editor (uses $EDITOR).                   |
-| \f             | \f [name [args..]]         | List or execute favorite queries.                          |
-| \fd            | \fd [name]                 | Delete a favorite query.                                   |
-| \fs            | \fs name query             | Save a favorite query.                                     |
-| \l             | \l                         | List databases.                                            |
-| \llm           | \ai                        | Interrogate an LLM.                                        |
-| \once          | \o [-o] filename           | Append next result to an output file (overwrite using -o). |
-| \pipe_once     | \| command                 | Send next result to a subprocess.                          |
-| \timing        | \t                         | Toggle timing of commands.                                 |
-| connect        | \r                         | Reconnect to the database. Optional database argument.     |
-| delimiter      | <null>                     | Change SQL delimiter.                                      |
-| exit           | \q                         | Exit.                                                      |
-| help           | \?                         | Show this help.                                            |
-| nopager        | \n                         | Disable pager, print to stdout.                            |
-| notee          | notee                      | Stop writing results to an output file.                    |
-| nowarnings     | \w                         | Disable automatic warnings display.                        |
-| pager          | \P [command]               | Set PAGER. Print the query results via PAGER.              |
-| prompt         | \R                         | Change prompt format.                                      |
-| quit           | \q                         | Quit.                                                      |
-| redirectformat | \Tr                        | Change the table format used to output redirected results. |
-| rehash         | \#                         | Refresh auto-completions.                                  |
-| source         | \. filename                | Execute commands from file.                                |
-| status         | \s                         | Get status information from the server.                    |
-| system         | system [command]           | Execute a system shell commmand.                           |
-| tableformat    | \T                         | Change the table format used to output results.            |
-| tee            | tee [-o] filename          | Append all results to an output file (overwrite using -o). |
-| use            | \u                         | Change to a new database.                                  |
-| warnings       | \W                         | Enable automatic warnings display.                         |
-| watch          | watch [seconds] [-c] query | Executes the query every [seconds] seconds (by default 5). |
-+----------------+----------------------------+------------------------------------------------------------+
+mycli> /help
++-----------------+----------+---------------------------------+-------------------------------------------------------------+
+| Command         | Shortcut | Usage                           | Description                                                 |
++-----------------+----------+---------------------------------+-------------------------------------------------------------+
+| /bug            | <null>   | /bug                            | File a bug on GitHub.                                       |
+| /clip           | <null>   | /clip | <query>\clip            | Copy query to the system clipboard.                         |
+| /dt             | <null>   | /dt[+] [table]                  | List or describe tables.                                    |
+| /edit           | /e       | /edit <filename> | <query>\edit | Edit query with editor (uses $VISUAL or $EDITOR).           |
+| /f              | <null>   | /f [name [args..]]              | List or execute favorite queries.                           |
+| /fd             | <null>   | /fd <name>                      | Delete a favorite query.                                    |
+| /fs             | <null>   | /fs <name> <query>              | Save a favorite query.                                      |
+| \g              | <null>   | <query>\g                       | Display query results (mnemonic: go).                       |
+| \G              | <null>   | <query>\G                       | Display query results vertically.                           |
+| /l              | <null>   | /l                              | List databases.                                             |
+| /llm            | /ai      | /llm [arguments]                | Interrogate an LLM.  See "/llm help".                       |
+| /once           | /o       | /once [-o] <filename>           | Append next result to an output file (overwrite using -o).  |
+| /pipe_once      | /|       | /pipe_once <command>            | Send next result to a subprocess.                           |
+| /timing         | /t       | /timing                         | Toggle timing of queries.                                   |
+| /connect        | /r       | /connect [database]             | Reconnect to the server, optionally switching databases.    |
+| /delimiter      | <null>   | /delimiter <string>             | Change end-of-statement delimiter.                          |
+| /exit           | /q       | /exit                           | Exit.                                                       |
+| /help           | /?       | /help [term]                    | Show this table, or search for help on a term.              |
+| /nopager        | /n       | /nopager                        | Disable pager; print to stdout.                             |
+| /notee          | <null>   | /notee                          | Stop writing results to an output file.                     |
+| /nowarnings     | /w       | /nowarnings                     | Disable automatic warnings display.                         |
+| /pager          | /P       | /pager [command]                | Set pager to [command]. Print query results via pager.      |
+| /prompt         | /R       | /prompt <string>                | Change prompt format.                                       |
+| /quit           | /q       | /quit                           | Quit.                                                       |
+| /redirectformat | /Tr      | /redirectformat <format>        | Change the table format used to output redirected results.  |
+| /rehash         | /#       | /rehash                         | Refresh auto-completions.                                   |
+| /source         | /.       | /source <filename>              | Execute queries from a file.                                |
+| /status         | /s       | /status                         | Get status information from the server.                     |
+| /system         | <null>   | /system [-r] <command>          | Execute a system shell command (raw mode with -r).          |
+| /tableformat    | /T       | /tableformat <format>           | Change the table format used to output interactive results. |
+| /tee            | <null>   | /tee [-o] <filename>            | Append all results to an output file (overwrite using -o).  |
+| /use            | /u       | /use <database>                 | Change to a new database.                                   |
+| /warnings       | /W       | /warnings                       | Enable automatic warnings display.                          |
+| /watch          | <null>   | /watch [seconds] [-c] <query>   | Execute query every [seconds] seconds (5 by default).       |
++-----------------+----------+---------------------------------+-------------------------------------------------------------+
+Use \backslash forms when at end-of-line.
+Docs index — https://mycli.net/docs
 ```
 
 Most commands have a long and short form. Most of the commands starting
@@ -62,157 +66,157 @@ semicolon.
     Send the current statement to the system clipboard.  This is used at the
     beginning or end of a statement, e.g. `select 1\clip`.
 
-* <a name="dt"></a> `\dt`, `\dt[+] [table]`
+* <a name="dt"></a> `/dt`, `/dt[+] [table]`
 
     List the tables in the default database (when used without any parameters).
     Describe a table (when passed a parameter).
 
     The optional `+` verbose indicator can be used to toggle whether or not the `CREATE TABLE` statement for the table is shown.
 
-    The `\dt` commands are equivalent to running `SHOW TABLES`, `SHOW COLUMNS FROM
+    The `/dt` commands are equivalent to running `SHOW TABLES`, `SHOW COLUMNS FROM
     [table_name]`, and `SHOW CREATE TABLE [table_name]`.
 
-* <a name="e"></a> `\e <filename>`, `<query>\e`
+* <a name="e"></a> `/edit <filename>`, `<query>\edit`
 
     Edit the current statement with an editor (uses the environment variable `$EDITOR`)
     or open a file.  If this is entered with an empty line, it will populate the editor
-    with the previous query.  `\e` is generally equivalent to the keystroke sequence
+    with the previous query.  `/edit` is generally equivalent to the keystroke sequence
     <kbd>control</kbd>-<kbd>x</kbd> <kbd>control</kbd>-<kbd>e</kbd>.
 
-* <a name="f"></a> `\f`, `\f <name> [arg, arg, ..]`
+* <a name="f"></a> `/f`, `/f <name> [arg, arg, ..]`
 
     List or execute favorite queries. If the favorite query requires parameters,
-    they can be passed to the query after the name, e.g., `\f users_by_name
+    they can be passed to the query after the name, e.g., `/f users_by_name
     "Teddy Roosevelt"`. See [Favorite Queries]({filename}/pages/favorites.md) for more information.
 
-* <a name="fd"></a> `\fd <name>`
+* <a name="fd"></a> `/fd <name>`
 
     Delete a favorite query.
 
-* <a name="fs"></a> `\fs <name> <query>`
+* <a name="fs"></a> `/fs <name> <query>`
 
     Save a favorite query. Favorite queries support shell-style parameter
     substitution. See [Favorite Queries]({filename}/pages/favorites.md) for more information.
 
-* <a name="l"></a> `\l`
+* <a name="l"></a> `/l`
 
     List the databases on the MySQL server host. This is equivalent to running
     `SHOW DATABASES`.
 
-* <a name="llm"></a> `\llm <question>`
+* <a name="llm"></a> `/llm <question>`
 
-    Interact with an LLM using natural language.  See [Using the \llm Command]({filename}/pages/llm.md).
+    Interact with an LLM using natural language.  See [Using the /llm Command]({filename}/pages/llm.md).
 
-* <a name="once"></a> `once <filename>`, `\o [-o] <filename>`
+* <a name="once"></a> `/once <filename>`, `/o [-o] <filename>`
 
     Output the next query's results to an output file. Defaults to
     append mode. Use `-o` to overwrite any existing file content.
     Also consider using shell-style redirects `$> <filename>` or
     `$>> <filename>` after your SQL statement.
 
-* <a name="pipe_once"></a> `pipe_once <command>`, `\| <command>`
+* <a name="pipe_once"></a> `/pipe_once <command>`, `/| <command>`
 
     Output the next query's results to a shell command.  Also
     consider using the shell-style redirect `$| <command` after
     your SQL statement, as in `SELECT 1 $| wc;`.
 
-* <a name="timing"></a> `timing`, `\t`
+* <a name="timing"></a> `/timing`, `/t`
 
     Toggle whether or not the time it takes to execute a statement is displayed
     below the results.
 
-* <a name="connect"></a> `connect [database]`, `\r [database]`
+* <a name="connect"></a> `/connect [database]`, `/r [database]`
 
     Reconnect to the server. You can optionally supply a database name that
     will be set as the default database for your connection.
 
-* <a name="delimiter"></a> `delimiter <string>`
+* <a name="delimiter"></a> `/delimiter <string>`
 
     Set the SQL end-of-statement delimiter, which is `;` by default.  Some
     mycli functionality may depend on the delimiter being `;`.
 
-* <a name="quit"></a> `quit`, `exit`, `\q`
+* <a name="quit"></a> `/quit`, `/exit`, `/q`
 
     Exit mycli.
 
-* <a name="help"></a> `help [name]`, `\? [name]`, `? [name]`
+* <a name="help"></a> `/help [name]`, `/? [name]`
 
     Display a help message listing mycli's commands.  As a special case, if
     optional `name` is given, search for help for `name` on the _server_.
 
-* <a name="nopager"></a> `nopager`, `\n`
+* <a name="nopager"></a> `/nopager`, `/n`
 
     Disable the use of pager software for outputting query results. For more
     information see the [pager section]({filename}/pages/pager.md) of the
     web documentation.
 
-* <a name="notee"></a> `notee`
+* <a name="notee"></a> `/notee`
 
     Disable output to the tee file. For more information, see the
-    [`tee` command](#tee).
+    [`/tee` command](#tee).
 
-* <a name="nowarnings"></a> `nowarnings`, `\w`
+* <a name="nowarnings"></a> `/nowarnings`, `/w`
 
     Disable automatic display of MySQL warnings from the server. For more
-    information, see the [`warnings` command](#warnings).
+    information, see the [`/warnings` command](#warnings).
 
-* <a name="pager"></a> `pager [command]`, `\P [command]`
+* <a name="pager"></a> `/pager [command]`, `/P [command]`
 
     Enable the use of a pager for outputting query results, by default `less`.
     Optionally, specify a different command that will be used as the pager. For
     more information see the [pager section]({filename}/pages/pager.md) of the
     web documentation.  The default pager may be set in your `~/.myclirc` file.
 
-* <a name="prompt"></a> `prompt`, `\R [format]`
+* <a name="prompt"></a> `/prompt`, `/R [format]`
 
     Change the prompt format. The default is `\t \u@\h:\d> `. See the
     [prompt]({filename}/pages/prompt.md) documentation for more information.
 
-* <a name="redirectformat"></a> `redirecformat [format]`, `\Tr [format]`
+* <a name="redirectformat"></a> `/redirecformat [format]`, `/Tr [format]`
 
     Change the output format for shell-style redirections.  Run the command
     without specifying a format to see the possible values.  The default is
     `csv`.
 
-* <a name="rehash"></a> `rehash`, `\#`
+* <a name="rehash"></a> `/rehash`, `/#`
 
     Refresh the cached auto-completion data. (This is the list of databases,
     tables, columns that auto-complete when you are typing.)
 
-* <a name="source"></a> `source <filename>`, `\. <filename>`
+* <a name="source"></a> `/source <filename>`, `/. <filename>`
 
     Execute the SQL commands from the named file.
 
-* <a name="status"></a> `status`, `\s`
+* <a name="status"></a> `/status`, `/s`
 
     Display status information about the client machine, server, and
     connection you are using.
 
-* <a name="system"></a> `system <command>`
+* <a name="system"></a> `/system <command>`
 
     Execute a shell command and outputs the results.
 
-* <a name="tableformat"></a> `tableformat [format]`, `\T [format]`
+* <a name="tableformat"></a> `/tableformat [format]`, `/T [format]`
 
     Change the interactive tabular output format. Run the command without
     specifying a format to see the possible values.
 
-* <a name="tee"></a> `tee [-o] <filename>`
+* <a name="tee"></a> `/tee [-o] <filename>`
 
     Log all queries/commands and their output to `filename`. Defaults to
     append mode. Use `-o` to overwrite any existing file content. To disable
-    this, see the [`notee` command](#notee).
+    this, see the [`/notee` command](#notee).
 
-* <a name="use"></a> `use <db_name>`, `\u <db_name>`
+* <a name="use"></a> `/use <db_name>`, `/u <db_name>`
 
     Use `db_name` as the default database.
 
-* <a name="warnings"></a> `warnings`, `\W`
+* <a name="warnings"></a> `/warnings`, `/W`
 
     Enable automatic display of MySQL warnings from the server.  This is the
     equivalent of running `SHOW WARNINGS` after every statement.
 
-* <a name="watch"></a> `watch [seconds] [-c] query`
+* <a name="watch"></a> `/watch [seconds] [-c] query`
 
     Repeatedly execute a query every `n` seconds. The default interval is `5`
     seconds. `-c` can be used to clear the screen after every iteration.

--- a/content/pages/config.md
+++ b/content/pages/config.md
@@ -315,7 +315,7 @@ output.null = "#808080"
 
 # Favorite queries.
 # You can add your favorite queries here. They will be available in the
-# REPL when you type `\f` or `\f <query_name>`.
+# REPL when you type `/f` or `/f <query_name>`.
 [favorite_queries]
 # example = "SELECT * FROM example_table WHERE id = 1"
 

--- a/content/pages/editor.md
+++ b/content/pages/editor.md
@@ -2,23 +2,27 @@ Title: Editor
 Slug: editor
 status: hidden
 
-One of the most useful slash commands is `\e`. This will launch an editor to
-edit the current query (or previous query, if the current query is blank).
+One of the most useful slash commands is `/edit` or `\edit`. This can be used
+to launch an editor to edit the current query (or previous query, if the
+current line is otherwise blank).
 
+When used at the end-of-line, we must use the backslash form `\edit` to
+avoid ambiguity with valid SQL.
 
 Here are some examples:
 
 ```
+# /edit alone will launch the default editor (read from the $EDITOR or $VISUAL
+# environment variables).  It will put the _previous_ query in the editor,
+# and the query will be populated back into the prompt once the edit session
+# is exited.
+> /edit
 
-# This will launch the default editor (read from $EDITOR env variable).
-# It will put the previous query in the editor's buffer.
-> \e
+# \edit at end-of-line will open the default editor with the query-so-far
+# in the editor.
+> SELECT * FROM \edit
 
-# This will open the default editor with the current query in the buffer.
-> SELECT * FROM \e
-
-# This will open an existing file in the editor and the contents of the file
-  will be populated into the prompt once the file is saved.
-> \e <filename>
-
+# /edit followed by an argument refers to a file.  This will open an existing
+# file in the editor.
+> /edit <filename>
 ```

--- a/content/pages/favorites.md
+++ b/content/pages/favorites.md
@@ -7,22 +7,22 @@ with a short name.
 
 Commands:
 
-`\f` - list all favorite queries.
+`/f` - list all favorite queries.
 
-`\f <name>` - Invoke a favorite query by its name.
+`/f <name>` - Invoke a favorite query by its name.
 
-`\fs <name> <query>` - Save a new favorite query called `<name>`.
+`/fs <name> <query>` - Save a new favorite query called `<name>`.
 
-`\fd <name>` - Delete an existing favorite query by its name.
+`/fd <name>` - Delete an existing favorite query by its name.
 
 Examples:
 
 ```sql
 # Save a new favorite query.
-> \fs simple select * from abc where a is not Null;
+> /fs simple select * from abc where a is not Null;
 
 # List all favorite queries.
-> \f
+> /f
 +--------+---------------------------------------+
 | Name   | Query                                 |
 |--------+---------------------------------------|
@@ -30,7 +30,7 @@ Examples:
 +--------+---------------------------------------+
 
 # Run a favorite query.
-> \f simple
+> /f simple
 +--------+--------+
 | a      | b      |
 |--------+--------|
@@ -38,7 +38,7 @@ Examples:
 +--------+--------+
 
 # Delete a favorite query.
-> \fd simple
+> /fd simple
 simple: Deleted
 ```
 
@@ -49,12 +49,12 @@ query with parameters as placeholders (e.g. `$1`, `$2`,
 `$3`, _etc._):
 
 ```sql
-\fs user_by_name select * from users where name = '$1'
+/fs user_by_name select * from users where name = '$1'
 ```
 
 When you call a favorite query with parameters, just add the parameters after
 the query's name. You can put quotes around arguments that include spaces.
 
 ```sql
-\f user_by_name "Skelly McDermott"
+/f user_by_name "Skelly McDermott"
 ```

--- a/content/pages/llm.md
+++ b/content/pages/llm.md
@@ -2,11 +2,11 @@ Title: LLM
 Slug: llm
 status: hidden
 
-# Using the \llm Command (AI-assisted SQL)
+# Using the /llm Command (AI-assisted SQL)
 
-The `\llm` special command lets you ask natural-language questions and get SQL proposed for you. It uses the open‑source `llm` CLI under the hood and enriches your prompt with database context (schema and one sample row per table) so answers can include runnable SQL.
+The `/llm` special command lets you ask natural-language questions and get SQL proposed for you. It uses the open‑source `llm` CLI under the hood and enriches your prompt with database context (schema and one sample row per table) so answers can include runnable SQL.
 
-Alias: `\ai` works the same as `\llm`.
+Alias: `/ai` works the same as `/llm`.
 
 ---
 
@@ -24,13 +24,13 @@ pip install llm
 2) From the mycli prompt, configure your API key (only needed for remote providers like OpenAI):
 
 ```text
-\llm keys set openai
+/llm keys set openai
 ```
 
 3) Ask a question. The response’s SQL (inside a ```sql fenced block) is extracted and pre-filled at the prompt:
 
 ```text
-World> \llm "Capital of India?"
+World> /llm "Capital of India?"
 -- Answer text from the model...
 -- ```sql
 -- SELECT ...;
@@ -44,7 +44,7 @@ You can now hit Enter to run, or edit the query first.
 
 ## What Context Is Sent
 
-When you ask a plain question via `\llm "..."`, mycli:
+When you ask a plain question via `/llm "..."`, mycli:
 - Sends your question.
 - Adds your current database schema: table names with column types.
 - Adds one sample row (if available) from each table.
@@ -57,27 +57,27 @@ Note: Context is gathered from the current connection. If you are not connected,
 
 ## Using `llm` Subcommands from mycli
 
-You can run any `llm` CLI subcommand by prefixing it with `\llm` inside mycli. Examples:
+You can run any `llm` CLI subcommand by prefixing it with `/llm` inside mycli. Examples:
 
 - List models:
   ```text
-  \llm models
+  /llm models
   ```
 - Set the default model:
   ```text
-  \llm models default gpt-5
+  /llm models default gpt-5
   ```
 - Set provider API key:
   ```text
-  \llm keys set openai
+  /llm keys set openai
   ```
 - Install a plugin (e.g., local models via Ollama):
   ```text
-  \llm install llm-ollama
+  /llm install llm-ollama
   ```
   After installing or uninstalling plugins, mycli will restart to pick up new commands.
 
-Tab completion works for `\llm` subcommands, and even for model IDs under `models default`.
+Tab completion works for `/llm` subcommands, and even for model IDs under `models default`.
 
 Aside: <https://ollama.com/> for using local models.
 
@@ -88,7 +88,7 @@ Aside: <https://ollama.com/> for using local models.
 Ask your question in quotes. mycli sends database context and extracts a SQL block if present.
 
 ```text
-World> \llm "Most visited urls?"
+World> /llm "Most visited urls?"
 ```
 
 Behavior:
@@ -102,9 +102,9 @@ Behavior:
 Use `-c` to ask a follow‑up that continues the previous conversation with the model. This does not re-send the DB context; it relies on the ongoing thread.
 
 ```text
-World> \llm "Top 10 customers by spend"
+World> /llm "Top 10 customers by spend"
 -- model returns analysis and a ```sql block; SQL is prefilled
-World> \llm -c "Now include each customer's email and order count"
+World> /llm -c "Now include each customer's email and order count"
 ```
 
 Behavior:
@@ -119,29 +119,29 @@ Behavior:
 
 - List available models:
   ```text
-  World> \llm models
+  World> /llm models
   ```
 
 - Change default model:
   ```text
-  World> \llm models default llama3
+  World> /llm models default llama3
   ```
 
 - Set API key (for providers that require it):
   ```text
-  World> \llm keys set openai
+  World> /llm keys set openai
   ```
 
 - Ask a question with context:
   ```text
-  World> \llm "Capital of India?"
+  World> /llm "Capital of India?"
   ```
 
 - Use a local model (after installing a plugin such as `llm-ollama`):
   ```text
-  World> \llm install llm-ollama
-  World> \llm models default llama3
-  World> \llm "Top 10 customers by spend"
+  World> /llm install llm-ollama
+  World> /llm models default llama3
+  World> /llm "Top 10 customers by spend"
   ```
 
 See: <https://ollama.com/> for details.
@@ -153,13 +153,13 @@ See: <https://ollama.com/> for details.
 mycli uses a saved `llm` template named `mycli-llm-template` for contextual questions. You can view or edit it:
 
 ```text
-World> \llm templates edit mycli-llm-template
+World> /llm templates edit mycli-llm-template
 ```
 
 Tip: After first use, mycli ensures this template exists. To just view it without editing, use:
 
 ```text
-World> \llm templates show mycli-llm-template
+World> /llm templates show mycli-llm-template
 ```
 
 ---
@@ -168,15 +168,15 @@ World> \llm templates show mycli-llm-template
 
 - No SQL pre-fill: Ensure the model’s response includes a ```sql fenced block. The built‑in prompt encourages this, but some models may omit it; try asking the model to include SQL in a ```sql block.
 - Not connected to a database: Contextual questions require a live connection. Connect first. Follow‑ups with `-c` only help after a successful contextual call.
-- Plugin changes not recognized: After `\llm install` or `\llm uninstall`, mycli restarts automatically to load new commands.
-- Provider/API issues: Use `\llm keys list` and `\llm keys set <provider>` to check credentials. Use `\llm models` to confirm available models.
+- Plugin changes not recognized: After `/llm install` or `/llm uninstall`, mycli restarts automatically to load new commands.
+- Provider/API issues: Use `/llm keys list` and `/llm keys set <provider>` to check credentials. Use `/llm models` to confirm available models.
 
 ---
 
 ## Notes and Safety
 
 - Data sent: Contextual questions send schema (table/column names and types) and a single sample row per table. Review your data sensitivity policies before using remote models; prefer local models (such as ollama) if needed.
-- Help: Running `\llm` with no arguments shows a short usage message.
+- Help: Running `/llm` with no arguments shows a short usage message.
 
 ## Turning Off LLM Support
 


### PR DESCRIPTION
 * prefer to advertise forward-slash /command forms
 * additional rewrites in `editor.md`
 * replace entire /help block in `commands.md`