### PR TITLE
Collected formatting/spacing changes

### DIFF
--- a/content/pages/1.install.md
+++ b/content/pages/1.install.md
@@ -7,6 +7,7 @@ Mycli is tested on macOS and Linux. It runs on Python 3.10+.
 
 Some testing is also done on Windows and WSL, but there are known limitations.
 
+</br>
 # Other Software:
 
 You may also want to install [less] and [fzf] for pager support and fuzzy history
@@ -16,6 +17,7 @@ search.  `less` is usually installed by default on Mac and Linux systems.
 requirement, but is highly recommended.  [pygments] can also work with `fzf`
 to colorize fuzzy history search.
 
+</br>
 # Python Package:
 
 The recommended way to install mycli is via the pip package manager ([installation instructions for pip](https://pip.pypa.io/en/stable/installing/)),
@@ -34,6 +36,7 @@ To install specific versions, you may use _e.g._
 The `[all]` ensures that optional extras such as LLM support are installed.
 If you don't want the extras, `[all]` can be omitted.
 
+</br>
 # macOS
 
 The easiest way install mycli on a Mac is to use [Homebrew].
@@ -45,11 +48,13 @@ included in the below command:
     :::bash
     $ brew update && brew install mycli fzf pygments
 
+</br>
 # Linux
 
 Mycli is provided by OS package maintainers in many distributions. These
 packages could be substantially out of date compared to pip/PyPi.
 
+</br>
 ## Arch, Manjaro
 
 You can install mycli and recommended other packages from the AUR:
@@ -58,6 +63,7 @@ You can install mycli and recommended other packages from the AUR:
 yay -S mycli fzf python-pygments
 ```
 
+</br>
 ## Debian, Ubuntu
 
 On Debian and Ubuntu distributions, you can install mycli and recommended
@@ -67,6 +73,7 @@ other packages using `apt`:
 sudo apt-get install mycli fzf python3-pygments
 ```
 
+</br>
 ## Fedora
 
 Fedora has a package available for mycli; you can install it and recommended
@@ -76,6 +83,7 @@ other packages using `dnf`:
 sudo dnf install mycli fzf python-pygments
 ```
 
+</br>
 # Windows
 
 ## Option 1: Native Windows
@@ -90,6 +98,7 @@ modifications, but this configuration isn't supported software at this time.
 
 PRs to address shortcomings on Windows would be welcome!
 
+</br>
 ## Option 2: WSL
 
 Mycli is more compatible with WSL than with native Windows, though still not

--- a/content/pages/2.screenshots.md
+++ b/content/pages/2.screenshots.md
@@ -1,4 +1,4 @@
-Title: Screenshots
+Title: Gallery
 Slug: screenshots
 
 

--- a/content/pages/3.docs.md
+++ b/content/pages/3.docs.md
@@ -1,4 +1,4 @@
-Title: Docs
+Title: Doc
 Slug: docs
 
 </br>

--- a/content/pages/favorites.md
+++ b/content/pages/favorites.md
@@ -17,7 +17,7 @@ Commands:
 
 Examples:
 
-```sql
+```text
 # Save a new favorite query.
 > /fs simple select * from abc where a is not Null;
 

--- a/content/pages/llm.md
+++ b/content/pages/llm.md
@@ -182,6 +182,8 @@ World> /llm templates show mycli-llm-template
 - Data sent: Contextual questions send schema (table/column names and types) and a single sample row per table. Review your data sensitivity policies before using remote models; prefer local models (such as ollama) if needed.
 - Help: Running `/llm` with no arguments shows a short usage message.
 
+----
+
 ## Turning Off LLM Support
 
 To turn off LLM support even when the `llm` dependency is installed, set the `MYCLI_LLM_OFF` environment variable:
@@ -190,7 +192,6 @@ export MYCLI_LLM_OFF=1
 ```
 
 This may be desirable for faster startup times.
-
 
 ---
 

--- a/content/pages/pager.md
+++ b/content/pages/pager.md
@@ -21,11 +21,13 @@ PAGER set to less.
 Pager disabled.
 ```
 
+</br>
 ## Disable Paging
 
 You can disable the pager by adding `enable_pager = False` to your `~/.myclirc`
 file. See [Configuration](/config) for more information.
 
+</br>
 ## Pager Behavior
 
 On macOS and Linux, the pager will default to `less` for most users. `less`


### PR DESCRIPTION
after viewing preview

also changing Docs title to Doc to try to improve navbar arrangement, and similarly Screenshots to Gallery.  These are sufficient to bring Blog back to the main navbar (it was wrapping).