### PR TITLE
Boost Connect section in Docs page

### DIFF
--- a/content/pages/3.docs.md
+++ b/content/pages/3.docs.md
@@ -19,6 +19,12 @@ The config file for mycli is located in the user's home folder (`~/.myclirc`).
 
 </br>
 
+## [Connect]({filename}/pages/connect.md)<a name="connect"></a>
+
+How to connect to a MySQL compatible server using mycli.
+
+</br>
+
 ## [Colors]({filename}/pages/syntax.md)<a name="colors"></a>
 
 Syntax highlighting has plenty of themes that can be changed via the [config]({filename}/pages/config.md) file.
@@ -115,9 +121,3 @@ can be configured or disabled.
 ## [Prompt]({filename}/pages/prompt.md)<a name="prompt"></a>
 
 Mycli has a configurable prompt.
-
-</br>
-
-## [Connect]({filename}/pages/connect.md)<a name="connect"></a>
-
-How to connect to a MySQL compatible server using mycli.


### PR DESCRIPTION
It didn't make much sense that how-to-connect was last.